### PR TITLE
refactor: remove push trigger and adjust issue comment types in PR Ag…

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     types: [opened, reopened, ready_for_review]
   issue_comment:
-    types: [created, edited]
+    types: [created]
 jobs:
   pr_agent_job:
     if: ${{ github.event.sender.type != 'Bot' }}


### PR DESCRIPTION
### **User description**
…ent workflow


___

### **PR Type**
Enhancement


___

### **Description**
- Removes the `push` event trigger.

- Triggers workflow on issue comment creation and edits.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Before
      A["Push to 'pr-test'"]
      B["PR: opened, reopened, ready_for_review"]
      C["Issue Comment"]
  end
  subgraph After
      D["PR: opened, reopened, ready_for_review"]
      E["Issue Comment: created, edited"]
  end
  A -- "triggers" --> F{{"PR Agent Workflow"}}
  B -- "triggers" --> F
  C -- "triggers" --> F
  D -- "triggers" --> G{{"PR Agent Workflow"}}
  E -- "triggers" --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-agent.yml</strong><dd><code>Update GitHub Actions workflow triggers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-agent.yml

<ul><li>Removes the <code>on.push</code> trigger, which was configured for the <code>pr-test</code> <br>branch.<br> <li> Specifies that the <code>issue_comment</code> trigger should only activate on <br><code>created</code> and <code>edited</code> events.</ul>


</details>


  </td>
  <td><a href="https://github.com/wozniak-slawomir/personal-website/pull/85/files#diff-69fd3473f15a98f47918e81bc4d0ca86a71131f21db13b39bebf76d27cf483b4">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

